### PR TITLE
random stage1 test for gpu ecm

### DIFF
--- a/check.sage
+++ b/check.sage
@@ -39,12 +39,7 @@ def FindGroupOrderParam2(p,s):
 
 # for parameter sigma = 3:s
 def FindGroupOrderParam3(p,s):
-   K = GF(p)
-   d = K(s/2^32)
-   A = 4*d-2
-   B = 4*A+10
-   E = EllipticCurve(K,[0,A/B,0,1/B^2,0])
-   return factor(E.cardinality())
+   return FindGroupOrderA (p, 4*s/2^32-2)
 
 def FindGroupOrderParam (p, sigma, param):
    if param == 0:
@@ -87,7 +82,7 @@ def is_found(l, B1, B2):
       if l[i][0]^l[i][1] > B1:
          return False
    return True
-  
+
 # check if a prime p is found with bounds B1 and B2,
 # for parameter 'param' and sigma in [sigma_min,sigma_max-1]
 # check_found ("./ecm", 31622776601683800097, 11000, 1873422, 0, 1000)
@@ -98,6 +93,7 @@ def check_found (ecm, p, B1, B2, param, sigma_max):
    assert (is_prime (p))
    e2 = 0
    e3 = 0
+   tested = 0
    tries = 0
    for sigma in range(sigma_max):
       try:
@@ -110,12 +106,13 @@ def check_found (ecm, p, B1, B2, param, sigma_max):
       if l[1][0] == 3:
          e3 += l[1][1]
       if is_found (l, B1, B2):
+         tested += 1
          # check the factor is really found
          check_found_aux (ecm, p, B1, B2, param, sigma)
-   print tries, 1.0*e2/tries, 1.0*e3/tries, 2.0^(e2/tries)*3.0^(e3/tries)
+   print tries, tested, 1.0*e2/tries, 1.0*e3/tries, 2.0^(e2/tries)*3.0^(e3/tries)
 
 # check all parametrizations 0, 1, 2, 3
-# check_found_all ("./ecm", 31622776601683800097, 11000, 1873422, 1000)
+#check_found_all ("./ecm", 31622776601683800097, 11000, 1873422, 200)
 def check_found_all (ecm, p, B1, B2, sigma_max):
    for param in range(4):
       check_found (ecm, p, B1, B2, param, sigma_max)

--- a/ecm-gpu.h
+++ b/ecm-gpu.h
@@ -21,7 +21,7 @@
   typedef int carry_t;
 #endif
 
-#define VOL volatile 
+#define VOL volatile
 //#define VOL
 
 #ifndef ECM_GPU_CURVES_BY_BLOCK
@@ -43,13 +43,13 @@ typedef carry_t VOL bigint_t[ECM_GPU_NB_DIGITS];
 #ifdef WITH_GPU
 int gpu_ecm (mpz_t, mpz_t, int, mpz_t, mpz_t, mpz_t, double *, double, mpz_t,
              mpz_t, unsigned long, const int, int, int, int, int, int,
-             FILE*, FILE*, char*, char *, double, int (*)(void), mpz_t, 
+             FILE*, FILE*, char*, char *, double, int (*)(void), mpz_t,
              double *, int, int*, unsigned int*);
 #else
 int gpu_ecm ();
 #endif
 #define gpu_ecm_stage1 __ECM(gpu_ecm_stage1)
-int gpu_ecm_stage1 (mpz_t *, int *, mpz_t, mpz_t, unsigned int, unsigned int, 
+int gpu_ecm_stage1 (mpz_t *, int *, mpz_t, mpz_t, unsigned int, unsigned int,
                     float *, int);
 
 #endif

--- a/test_gpu_ecm.sage
+++ b/test_gpu_ecm.sage
@@ -11,45 +11,40 @@ GPU_PARAM = 3
 
 def GroupOrderParam0(p, sigma):
     K = GF(p)
-    v = (4*sigma) * K.gen()
-    u = (sigma^2 - 5) * K.gen()
+    v = K(4*sigma)
+    u = K(sigma^2 - 5)
     x = u^3
     b = 4*x*v
     a = (v-u)^3*(3*u+v)
     A = a/b-2
     x = x/v^3
     b = x^3 + A*x^2 + x
-    return EllipticCurve([0,b*A,0,b^2,0])
+    return EllipticCurve(K,[0,b*A,0,b^2,0])
+
+def GroupOrderA(p, s):
+    K = GF(p)
+    A = K(4 *s - 2);
+    b = K(16*s + 2);
+    return EllipticCurve(K,[0,b*A,0,b^2,0])
 
 # From parametrizations.c
 def GroupOrderParam2(p,sigma):
-   K = GF(p)
-   E = EllipticCurve(K,[0,36])
-   P = sigma*E(-3,3)
-   x,y = P.xy()
-   x3 = (3*x+y+6)/(2*(y-3))
-   A = -(3*x3^4+6*x3^2-1)/(4*x3^3)
-   d = K((A+2)/4)
-
-   a = K(4 *d - 2)
-   b = K(16*d + 2)
-   return EllipticCurve(K,[0,b*a,0,b^2,0])
+    K = GF(p)
+    E = EllipticCurve(K,[0,36])
+    P = sigma*E(-3,3)
+    x,y = P.xy()
+    x3 = (3*x+y+6)/(2*(y-3))
+    A = -(3*x3^4+6*x3^2-1)/(4*x3^3)
+    d = K((A+2)/4)
+    return GroupOrderA(p, d)
 
 def GroupOrderParam1(p, sigma):
     K = GF(p)
-    inv2_64 = inverse_mod(2 ^ 64, p)
-    s = K(sigma^2 * inv2_64)
-    A = K(4 *s - 2);
-    b = K(16*s + 2);
-    return EllipticCurve([0,b*A,0,b^2,0])
+    return GroupOrderA(p, K(sigma^2 / 2^64))
 
 def GroupOrderParam3(p, sigma):
     K = GF(p)
-    inv2_32 = inverse_mod(2 ^ 32, p)
-    s = K(sigma * inv2_32)
-    A = K(4 *s - 2);
-    b = K(16*s + 2);
-    return EllipticCurve([0,b*A,0,b^2,0])
+    return GroupOrderA(p, K(sigma / 2^32))
 
 def GroupOrder(param, prime, sigma):
     if param == 0:
@@ -68,21 +63,31 @@ def GroupOrder(param, prime, sigma):
 def testInternal():
     # Verify code is working.
 
-    # echo "78257675131877111603" | ecm -sigma "0:1057" 5000 15000-16000
-    assert GroupOrder(0, 78257675131877111603, 1057) == \
-        2^3 * 3 * 19 * 61 * 149 * 499 * 563 * 4337 * 15497
+    # echo "78257675131877111603" | ecm -sigma "0:4528" 3100 8000-9000
+    assert GroupOrder(0, 78257675131877111603, 4528) == \
+        2^3 * 3 * 71 * 563 * 1531 * 2153 * 3011 * 8219
+    # echo "78257675131877111603" | ecm -sigma "1:3396" 4800 8000-9000
+    assert GroupOrder(1, 78257675131877111603, 3396) == \
+        2^4 * 3 * 223 * 271 * 811 * 821 * 4799 * 8443
+    # echo "78257675131877111603" | ecm -sigma "2:1801" 2100 9000-9300
+    assert GroupOrder(2, 78257675131877111603, 1801) == \
+        2^9 * 3^3 * 23 * 41 * 47 * 67 * 101 * 2039 * 9257
+    # echo "78257675131877111603" | ecm -sigma "3:2012" 6000 8000-9000
+    assert GroupOrder(3, 78257675131877111603, 2012) == \
+        2^3 * 5^3 * 43^2 * 71 * 83 * 139 * 5779 * 8941
 
-    # echo "78257675131877111603" | ecm -sigma "1:1511" 17000 25000-26000
-    assert GroupOrder(1, 78257675131877111603, 1511) == \
-        2^6 * 3 * 5 * 7 * 193 * 293 * 491 * 16651 * 25189
-
-    # echo "78257675131877111603" | ecm -sigma "2:1272" 2000 88000-89000
-    assert GroupOrder(2, 78257675131877111603, 1272) == \
-        2^2 * 3^6 * 13 * 29 * 491 * 1117 * 1471 * 88237
-
-    # echo "78257675131877111603" | ecm -sigma "3:1203" 6000 73000-74000
-    assert GroupOrder(3, 78257675131877111603, 1203) == \
-        2^3 * 3^3 * 13 * 139 * 587 * 821 * 5693 * 73079
+    # echo "1082500099132634560519" | ecm -sigma "0:6677" 1200 5000-6000
+    assert GroupOrder(0, 1082500099132634560519, 6677) == \
+        2^2 * 3 * 5^2 * 7 * 139 * 677 * 887 * 947 * 1123 * 5807
+    # echo "1082500099132634560519" | ecm -sigma "1:1800" 4000 6000-7000
+    assert GroupOrder(1, 1082500099132634560519, 1800) == \
+        2^5 * 7^2 * 13 * 17 * 79 * 701 * 2647 * 3347 * 6367
+    # echo "1082500099132634560519" | ecm -sigma "2:2966" 2000 7000-8000
+    assert GroupOrder(2, 1082500099132634560519, 2966) == \
+        2^3 * 3^2 * 13 * 29 * 31^2 * 61 * 109 * 487 * 1709 * 7499
+    # echo "1082500099132634560519" | ecm -sigma "3:1600" 2000 3000-3100
+    assert GroupOrder(3, 1082500099132634560519, 1600) == \
+        2^3 * 3^3 * 7 * 23^2 * 37 * 67 * 71 * 1297 * 1933 * 3067
 
     # From Zimmermann, https://homepages.cwi.nl/~herman/Zimmermann.pdf
     assert GroupOrder(0, 322410908070969630339041359359164154612901586904078700184707, 20041348) == \
@@ -117,7 +122,7 @@ def smallGroupOrders(prime, param, B1, sigma_count):
         assert len(f) >= 1, (order, f)
 
         for p, k in f[:-1]:
-            if p ** k > B1:
+            if p ^ k > B1 :
                 break
         else:
             if f[-1][0] ** f[-1][1] <= B1:
@@ -167,21 +172,22 @@ def stage1Tests(N_size, prime_size, B1, param, sigma_count, seed=None):
             factor_by_sigma[sigma] *= prime
 
     if len(factor_by_sigma) == 0:
-        raise ValueError("No primes would be found in step1, lower prime_size or increase B1")
+        raise ValueError("No primes would be found in step 1, lower prime_size or increase B1")
 
     N_log2 = log(prod(N), 2).n()
     assert N_log2 < N_size, (N_size, N_log2, prime_size, pprime_count)
 
     N_str = "*".join(map(str, N))
-    print
-    print "N=" + N_str
-    print
-    print "Should find:"
-    for sigma, factor in sorted(factor_by_sigma.items()):
-        print "\tsigma %d => %d" % (sigma, factor)
+    # TODO add a verbose flag
+    # print
+    # print "N=" + N_str
+    # print
+    # print "Should find:"
+    # for sigma, f in sorted(factor_by_sigma.items()):
+    #    print "\tsigma %d => %d" % (sigma, f)
 
     # TODO pass in $ECM
-    cmd = "echo %s | ./ecm -gpu -gpucurves %d -sigma %d:%d %d" % (
+    cmd = "echo %s | ./ecm -gpu -gpucurves %d -sigma %d:%d %d 0" % (
         N_str, sigma_count, param, SIGMA_0, B1)
 
     print
@@ -196,39 +202,53 @@ def stage1Tests(N_size, prime_size, B1, param, sigma_count, seed=None):
 
     found_factors = {}
     for line in lines:
-        match = re.search("factor ([0-9]*) found.*-sigma [0-4]:([0-9]*)\)", line)
+        match = re.search("factor ([0-9]*) found in Step 1.*-sigma [0-4]:([0-9]*)\)", line)
         if match:
-            factor, sigma = map(int, match.groups())
+            f, sigma = map(int, match.groups())
             assert sigma not in found_factors
-            found_factors[sigma] = factor
+            found_factors[sigma] = f
 
-    success = found_factors == factor_by_sigma
+    perfect_match = factor_by_sigma == found_factors
+    near_match = True
 
     all_sigmas = set(factor_by_sigma.keys()) | set(found_factors.keys())
     for sigma in sorted(all_sigmas):
-        theory = factor_by_sigma.get(sigma, 0)
-        practice = found_factors.get(sigma, 0)
+        theory = factor_by_sigma.get(sigma, 1)
+        practice = found_factors.get(sigma, 1)
+        if theory > practice:
+            near_match = False
+
         if theory != practice:
             print "sigma=%d Expected to find %d, found %d" % (sigma, theory, practice)
-            assert success == False
+            if practice % theory == 0:
+                extra = practice / theory
+                f = factor(GroupOrder(param, extra, sigma))
+                print "\t", extra, sigma, f
 
     print
-    print "Result Matched" if success else "Bad Result"
-    if not success:
+    if perfect_match:
+        print "Results matched"
+    elif near_match:
+        print "Results were superset (GPU found extra)"
+    else:
+        print "Wrong results"
         sys.exit(1)
 
 
 if __name__ == "__main__":
-    #testInternal()
+    testInternal()
 
     # TODO pass -gpucurves, -reps, -seed
 
-    # For Nvidia gtx 970
-    sigma_count = 32 #832
+    seed = None
+    reps = 15
+    sigma_count = 64
+    N_bits = 1000
 
-    # Test N = 1000 bits, compossed of ~20 50-bit primes, found at B1=1e4
-    stage1Tests(1000, 30, 10^4, GPU_PARAM, sigma_count)
+    for i in range(reps):
+        # Test smallish primes (40 bits = 12 digit) at B1=1e4
+        stage1Tests(N_bits, 40, 10^4, GPU_PARAM, sigma_count, seed=seed)
 
-    # Test larger primes at B1=1e5
-    stage1Tests(1000, 60, 10^5, GPU_PARAM, sigma_count)
+        # Test larger primes at B1=1e5
+        stage1Tests(N_bits, 60, 10^5, GPU_PARAM, sigma_count)
 

--- a/test_gpu_ecm.sage
+++ b/test_gpu_ecm.sage
@@ -1,0 +1,234 @@
+import random
+import re
+import subprocess
+import sys
+
+# Start all sigma scans from this value
+SIGMA_0 = 1000
+
+# Currently GPU can only do param=3
+GPU_PARAM = 3
+
+def GroupOrderParam0(p, sigma):
+    K = GF(p)
+    v = (4*sigma) * K.gen()
+    u = (sigma^2 - 5) * K.gen()
+    x = u^3
+    b = 4*x*v
+    a = (v-u)^3*(3*u+v)
+    A = a/b-2
+    x = x/v^3
+    b = x^3 + A*x^2 + x
+    return EllipticCurve([0,b*A,0,b^2,0])
+
+# From parametrizations.c
+def GroupOrderParam2(p,sigma):
+   K = GF(p)
+   E = EllipticCurve(K,[0,36])
+   P = sigma*E(-3,3)
+   x,y = P.xy()
+   x3 = (3*x+y+6)/(2*(y-3))
+   A = -(3*x3^4+6*x3^2-1)/(4*x3^3)
+   d = K((A+2)/4)
+
+   a = K(4 *d - 2)
+   b = K(16*d + 2)
+   return EllipticCurve(K,[0,b*a,0,b^2,0])
+
+def GroupOrderParam1(p, sigma):
+    K = GF(p)
+    inv2_64 = inverse_mod(2 ^ 64, p)
+    s = K(sigma^2 * inv2_64)
+    A = K(4 *s - 2);
+    b = K(16*s + 2);
+    return EllipticCurve([0,b*A,0,b^2,0])
+
+def GroupOrderParam3(p, sigma):
+    K = GF(p)
+    inv2_32 = inverse_mod(2 ^ 32, p)
+    s = K(sigma * inv2_32)
+    A = K(4 *s - 2);
+    b = K(16*s + 2);
+    return EllipticCurve([0,b*A,0,b^2,0])
+
+def GroupOrder(param, prime, sigma):
+    if param == 0:
+        ec = GroupOrderParam0(prime, sigma)
+    elif param == 1:
+        ec = GroupOrderParam1(prime, sigma)
+    elif param == 2:
+        ec = GroupOrderParam2(prime, sigma)
+    elif param == 3:
+        ec = GroupOrderParam3(prime, sigma)
+    else:
+        raise ValueError("Unknown param: " + str(param))
+
+    return ec.order()
+
+def testInternal():
+    # Verify code is working.
+
+    # echo "78257675131877111603" | ecm -sigma "0:1057" 5000 15000-16000
+    assert GroupOrder(0, 78257675131877111603, 1057) == \
+        2^3 * 3 * 19 * 61 * 149 * 499 * 563 * 4337 * 15497
+
+    # echo "78257675131877111603" | ecm -sigma "1:1511" 17000 25000-26000
+    assert GroupOrder(1, 78257675131877111603, 1511) == \
+        2^6 * 3 * 5 * 7 * 193 * 293 * 491 * 16651 * 25189
+
+    # echo "78257675131877111603" | ecm -sigma "2:1272" 2000 88000-89000
+    assert GroupOrder(2, 78257675131877111603, 1272) == \
+        2^2 * 3^6 * 13 * 29 * 491 * 1117 * 1471 * 88237
+
+    # echo "78257675131877111603" | ecm -sigma "3:1203" 6000 73000-74000
+    assert GroupOrder(3, 78257675131877111603, 1203) == \
+        2^3 * 3^3 * 13 * 139 * 587 * 821 * 5693 * 73079
+
+    # From Zimmermann, https://homepages.cwi.nl/~herman/Zimmermann.pdf
+    assert GroupOrder(0, 322410908070969630339041359359164154612901586904078700184707, 20041348) == \
+        2^4 * 3^2 * 391063 * 1197631 * 82011967 * 126033329 * 1926338723 * 4654300159 * 51585518429
+
+    # From David Broadhurst, https://lists.gforge.inria.fr/pipermail/ecm-discuss/2005-September/003790.html
+    assert GroupOrder(0, 73372650975767950626979890709193208431269141871367229612025497, 175923) == \
+        2^2 * 3^2 * 13 * 41 * 3389 * 3989 * 1662013 * 2782993 * 5013037 * 94921033 * 1144363489 * 112303943380877
+
+    # From David Broadhurst, https://lists.gforge.inria.fr/pipermail/ecm-discuss/2005-September/003792.html
+    assert GroupOrder(0, 2580118483169716809210552261225054520765090617558895237, 161957884569085) == \
+        2^2 * 3 * 1483 * 91381 * 103231 * 239587 * 1151317 * 1186033 * 1611697 * 4199071 * 6941601157
+
+    # From David Broadhurst, https://lists.gforge.inria.fr/pipermail/ecm-discuss/2005-September/003802.html
+    assert GroupOrder(0, 6314722182591714308391592266483806595696758378370807102207443753223500809, 2481305347) == \
+        2^3 * 3^6 * 11 * 13^2 * 17^4 * 31^2 * 53^2 * 163 * 449 * 853^2 * 3923^2 * 7489 * 11113 * \
+        23459^2 * 116531 * 1016891 * 580801721
+
+
+    print "Implementation successfully tested"
+
+
+def smallGroupOrders(prime, param, B1, sigma_count):
+    ''' Find list of sigmas that will find prime at with B1 <= B1'''
+    found = []
+
+    for sigma in range(SIGMA_0, SIGMA_0 + sigma_count):
+        order = GroupOrder(param, prime, sigma)
+        assert 1 <= order < 2 * prime, (prime, param, sigma, order)
+
+        f = factor(order)
+        assert len(f) >= 1, (order, f)
+
+        for p, k in f[:-1]:
+            if p ** k > B1:
+                break
+        else:
+            if f[-1][0] ** f[-1][1] <= B1:
+                found.append(sigma)
+
+    return found
+
+
+def stage1Tests(N_size, prime_size, B1, param, sigma_count, seed=None):
+    '''
+    Generate N such that many sigmas (SIGMA_0:SIGMA_0+sigma_count) have factors
+    Verify sigmas found factor in stage 1.
+    '''
+    assert param == GPU_PARAM, ("GPU only supports param=%d" % GPU_PARAM)
+    assert prime_size < N_size
+    assert N_size <= 1020
+    assert prime_size > 20
+
+    prime_count = N_size // prime_size
+    print
+    print "Testing GPU stage1: N = %d x %d bits primes @ B1=%d " % (
+        prime_count, prime_size, B1)
+
+    import random
+    if seed is None:
+        seed = random.randrange(2 ^ 32)
+    print "\tusing seed:", seed
+    random.seed(seed)
+
+    N = []
+    factor_by_sigma = {}
+    for pi in range(prime_count):
+        for test in range(100):
+            r = ZZ(random.randint(2 ^ (prime_size-1), 2 ^ prime_size))
+            prime = Primes().next(r)
+            if prime not in N:
+                N.append(prime)
+                break
+        else:
+            raise ValueError("Can't find enought primes at prime_size=%d" % prime_size)
+
+        sigmas = smallGroupOrders(prime, param, B1, sigma_count)
+        print "\t%2d: %20d found @ B1=%d by %s" % (pi, prime, B1, sigmas)
+        for sigma in sigmas:
+            if sigma not in factor_by_sigma:
+                factor_by_sigma[sigma] = 1
+            factor_by_sigma[sigma] *= prime
+
+    if len(factor_by_sigma) == 0:
+        raise ValueError("No primes would be found in step1, lower prime_size or increase B1")
+
+    N_log2 = log(prod(N), 2).n()
+    assert N_log2 < N_size, (N_size, N_log2, prime_size, pprime_count)
+
+    N_str = "*".join(map(str, N))
+    print
+    print "N=" + N_str
+    print
+    print "Should find:"
+    for sigma, factor in sorted(factor_by_sigma.items()):
+        print "\tsigma %d => %d" % (sigma, factor)
+
+    # TODO pass in $ECM
+    cmd = "echo %s | ./ecm -gpu -gpucurves %d -sigma %d:%d %d" % (
+        N_str, sigma_count, param, SIGMA_0, B1)
+
+    print
+    print (cmd)
+
+    try:
+        output = subprocess.check_output(cmd, shell=True, universal_newlines=True)
+        assert False, "Should have factors and had non-zero return"
+    except subprocess.CalledProcessError as e:
+        assert e.returncode in (2, 6, 8, 10, 14), e.returncode
+        lines = e.output.split("\n")
+
+    found_factors = {}
+    for line in lines:
+        match = re.search("factor ([0-9]*) found.*-sigma [0-4]:([0-9]*)\)", line)
+        if match:
+            factor, sigma = map(int, match.groups())
+            assert sigma not in found_factors
+            found_factors[sigma] = factor
+
+    success = found_factors == factor_by_sigma
+
+    all_sigmas = set(factor_by_sigma.keys()) | set(found_factors.keys())
+    for sigma in sorted(all_sigmas):
+        theory = factor_by_sigma.get(sigma, 0)
+        practice = found_factors.get(sigma, 0)
+        if theory != practice:
+            print "sigma=%d Expected to find %d, found %d" % (sigma, theory, practice)
+            assert success == False
+
+    print
+    print "Result Matched" if success else "Bad Result"
+    if not success:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    #testInternal()
+
+    # TODO pass -gpucurves, -reps, -seed
+
+    # For Nvidia gtx 970
+    sigma_count = 32 #832
+
+    # Test N = 1000 bits, compossed of ~20 50-bit primes, found at B1=1e4
+    stage1Tests(1000, 30, 10^4, GPU_PARAM, sigma_count)
+
+    # Test larger primes at B1=1e5
+    stage1Tests(1000, 60, 10^5, GPU_PARAM, sigma_count)
+


### PR DESCRIPTION
Example output (slightly trimmed)

```
Testing GPU stage1: N = 8 x 30 bits primes @ B1=10000 
	using seed: 96181936
	 0:           1061081501 found @ B1=10000 by [1000, 1001, 1004, 1005, 1011, 1015, 1017, 1018, 1020, 1022, 1026, 1028, 1030, 1032, 1034, 1035, 1039, 1046, 1050, 1051, 1052, 1053, 1055, 1059, 1060, 1061]
	 1:            713808247 found @ B1=10000 by [1000, 1002, 1004, 1006, 1007, 1010, 1013, 1015, 1023, 1025, 1026, 1027, 1030, 1033, 1035, 1041, 1047, 1049, 1050, 1053, 1055, 1057, 1062]
	 2:            958067501 found @ B1=10000 by [1005, 1007, 1008, 1015, 1019, 1021, 1026, 1037, 1039, 1041, 1055, 1057, 1059, 1061]
	 3:           1028632093 found @ B1=10000 by [1004, 1009, 1011, 1012, 1019, 1023, 1027, 1039, 1041, 1045, 1056, 1061, 1062, 1063]
	 4:            880623313 found @ B1=10000 by [1004, 1016, 1023, 1024, 1028, 1029, 1032, 1036, 1040, 1044, 1048, 1051, 1054]
	 5:           1057058879 found @ B1=10000 by [1001, 1005, 1019, 1020, 1023, 1024, 1027, 1028, 1030, 1033, 1036, 1038, 1045, 1051, 1052, 1055, 1058, 1062]
	 6:            673472687 found @ B1=10000 by [1002, 1005, 1007, 1008, 1012, 1013, 1015, 1017, 1019, 1021, 1022, 1023, 1024, 1025, 1029, 1034, 1036, 1044, 1046, 1053, 1054, 1058, 1059, 1060, 1062]
	 7:            794395027 found @ B1=10000 by [1006, 1015, 1017, 1020, 1021, 1023, 1030, 1034, 1047, 1048, 1050, 1056, 1061, 1062]

N=1061081501*713808247*958067501*1028632093*880623313*1057058879*673472687*794395027

Should find:
	sigma 1000 => 757408726152938747
	sigma 1001 => 1121625621974697379
	sigma 1002 => 480730358109849689
	sigma 1004 => 686089152444350846154530156112971423
	sigma 1005 => 723709073329224548146824264828664873
...

	sigma 1060 => 714609409604463187
	sigma 1061 => 830694697758297409658091400314690511
	sigma 1062 => 415238213620924230660273705750662153024971441
	sigma 1063 => 1028632093

echo 1061081501*713808247*958067501*1028632093*880623313*1057058879*673472687*794395027 | ./ecm -gpu -gpucurves 64 -sigma 3:1000 10000

Result Matched

Testing GPU stage1: N = 4 x 60 bits primes @ B1=100000 
	using seed: 952828668
  ***   Warning: increasing stack size to 2000000.
	 0:  1010733253460815663 found @ B1=100000 by [1003]
	 1:   945071087881464301 found @ B1=100000 by [1028]
	 2:   901209929429714789 found @ B1=100000 by [1047, 1063]
	 3:  1046212808266351763 found @ B1=100000 by []

N=1010733253460815663*945071087881464301*901209929429714789*1046212808266351763

Should find:
	sigma 1003 => 1010733253460815663
	sigma 1028 => 945071087881464301
	sigma 1047 => 901209929429714789
	sigma 1063 => 901209929429714789

echo 1010733253460815663*945071087881464301*901209929429714789*1046212808266351763 | ./ecm -gpu -gpucurves 64 -sigma 3:1000 100000

Result Matched
